### PR TITLE
[feat]実績テーブルの追加

### DIFF
--- a/my_db.py
+++ b/my_db.py
@@ -27,6 +27,15 @@ class Like(SQLModel, table=True):
     user_id: int | None = Field(default=None, foreign_key="user.id")
     message_id: int | None = Field(default=None, foreign_key="message.id")
     
+class Achievement(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    user_id: int | None = Field(default=None, foreign_key="user.id")
+    login_days: int = 0
+    likes_given: int = 0
+    likes_received: int = 0
+    comments_made: int = 0
+    rooms_created: int = 0
+    streams_viewed: int = 0
 
 sqlite_file_name = "database.db"
 sqlite_url = f"sqlite:///{sqlite_file_name}"


### PR DESCRIPTION
## 概要
実績テーブルを作成しid, user_id, login_days, likes_given, likes_received, comments_made, rooms_created, streams_viewedカラムを追加しました。

## 変更点
- 実績テーブルの作成
- レコード毎に固有のidをもつidカラム、Userへの外部キーをもつuser_idカラム、実績として集計するログイン日数、いいねをした回数、いいねをされた回数、コメントをした回数、ルームを作成した回数、配信を視聴した回数のカラムを追加