### PR TITLE
feat]いいねをしたユーザーとされたユーザーの実績の更新

### DIFF
--- a/main.py
+++ b/main.py
@@ -52,6 +52,12 @@ async def make_user(data: MakeUser, session: db.SessionDep):
     session.add(new_user)
     session.commit()
     session.refresh(new_user)
+    
+    #　実績テーブルの初期化
+    new_achievement = db.Achievement(user_id=new_user.id)
+    session.add(new_achievement)
+    session.commit()
+    
     return {
         "id": new_user.id,
         "name": new_user.name

--- a/my_db.py
+++ b/my_db.py
@@ -30,7 +30,7 @@ class Like(SQLModel, table=True):
 class Achievement(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     user_id: int | None = Field(default=None, foreign_key="user.id")
-    login_days: int = 0
+    login_days: int = 1 #登録した時点でログイン1日目になるため
     likes_given: int = 0
     likes_received: int = 0
     comments_made: int = 0


### PR DESCRIPTION
## 概要
新しくユーザー登録された時点で実績テーブルの初期化を行い、ユーザーがいいねをしたときにいいねをしたユーザーとされたユーザーの実績の更新をしました。

## 変更点
- 実績テーブルのログイン日数の初期値を0→1に変更
- 新しくユーザー登録時に実績テーブルの初期化をするコードの追加
- ユーザーがいいねをした時、いいねをしたユーザーの実績テーブルのlikes_givenを＋1、いいねをされたユーザーの実績テーブルのlikes_receivedを＋1するようなコードの追加