### PR TITLE
[feat]いいねを取消したユーザーと取消されたユーザーの実績の更新

### DIFF
--- a/main.py
+++ b/main.py
@@ -52,6 +52,12 @@ async def make_user(data: MakeUser, session: db.SessionDep):
     session.add(new_user)
     session.commit()
     session.refresh(new_user)
+    
+    #　実績テーブルの初期化
+    new_achievement = db.Achievement(user_id=new_user.id)
+    session.add(new_achievement)
+    session.commit()
+    
     return {
         "id": new_user.id,
         "name": new_user.name

--- a/main.py
+++ b/main.py
@@ -195,9 +195,14 @@ async def like_message(message_id: int, user_id: int, session: db.SessionDep):
         liker_achievement.likes_given += 1
         
     # メッセージの投稿者の実績（likes_received）を更新
-    receiver_achievement = session.exec(
-        db.select(db.Achievement).where(db.Achievement.user_id == message.user)
-    ).first()
+    # ユーザー名から User を検索
+    receiver_user = session.exec(db.select(db.User).where(db.User.name == message.user)).first()
+    # ユーザーが存在する場合のみ Achievement を取得しいいね数を増やす
+    receiver_achievement = None
+    if receiver_user:
+        receiver_achievement = session.exec(
+            db.select(db.Achievement).where(db.Achievement.user_id == receiver_user.id)
+        ).first()
     if receiver_achievement:
         receiver_achievement.likes_received += 1
     
@@ -232,9 +237,14 @@ async def unlike_message(message_id: int, user_id: int, session: db.SessionDep):
         liker_achievement.likes_given -= 1
         
     # メッセージの投稿者の実績（likes_received）を更新
-    receiver_achievement = session.exec(
-        db.select(db.Achievement).where(db.Achievement.user_id == message.user)
-    ).first()
+    # ユーザー名から User を検索
+    receiver_user = session.exec(db.select(db.User).where(db.User.name == message.user)).first()
+    # ユーザーが存在する場合のみ Achievement を取得しいいね数を減らす
+    receiver_achievement = None
+    if receiver_user:
+        receiver_achievement = session.exec(
+            db.select(db.Achievement).where(db.Achievement.user_id == receiver_user.id)
+        ).first()
     if receiver_achievement:
         receiver_achievement.likes_received -= 1
     

--- a/main.py
+++ b/main.py
@@ -68,10 +68,23 @@ async def get_user(user_id: int, session: db.SessionDep):
     user = session.get(db.User, user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
-    return {
+    archievement = session.exec(db.select(db.Achievement).filter(db.Achievement.user_id == user_id)).first()
+    output = {
         "id": user.id,
-        "name": user.name
+        "name": user.name,
     }
+    if archievement:
+        output["archievements"] = {
+            # "login_days": archievement.login_days,
+            "likes_given": archievement.likes_given,
+            "likes_received": archievement.likes_received,
+            # "comments_made": archievement.comments_made,
+            # "rooms_created": archievement.rooms_created,
+            # "streams_viewed": archievement.streams_viewed,
+        }
+    else:
+        output["archievements"] = {}
+    return output
 
 @app.post("/users/login")
 async def login_user(data: LoginUser, session: db.SessionDep):

--- a/my_db.py
+++ b/my_db.py
@@ -30,7 +30,7 @@ class Like(SQLModel, table=True):
 class Achievement(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     user_id: int | None = Field(default=None, foreign_key="user.id")
-    login_days: int = 0
+    login_days: int = 1 #登録した時点でログイン1日目になるため
     likes_given: int = 0
     likes_received: int = 0
     comments_made: int = 0


### PR DESCRIPTION
## 概要
ユーザーがいいねを取消したときにいいねをしたユーザーとされたユーザーの実績の更新をしました。

## 変更点
- ユーザーがいいねを取消した時、いいねをしたユーザーの実績テーブルのlikes_givenを-1、いいねをされたユーザーの実績テーブルのlikes_receivedを-1するようなコードの追加