### PR TITLE
[feat]メッセージ作成時にメッセージ投稿者の実績の更新

### DIFF
--- a/main.py
+++ b/main.py
@@ -78,7 +78,7 @@ async def get_user(user_id: int, session: db.SessionDep):
             # "login_days": archievement.login_days,
             "likes_given": archievement.likes_given,
             "likes_received": archievement.likes_received,
-            # "comments_made": archievement.comments_made,
+            "messages_made": archievement.messages_made,
             # "rooms_created": archievement.rooms_created,
             # "streams_viewed": archievement.streams_viewed,
         }

--- a/main.py
+++ b/main.py
@@ -145,6 +145,16 @@ async def make_message(room_id: int, data: MakeMessage, session: db.SessionDep):
         raise HTTPException(status_code=404, detail="Room not found")
     new_message = db.Message(user=data.user, message=data.message, room=room_id)
     session.add(new_message)
+    
+    # メッセージ投稿者の実績（messages_made）を更新
+    make_message_user = session.exec(db.select(db.User).where(db.User.name == data.user)).first()
+    if make_message_user:
+        make_message_achievement = session.exec(
+            db.select(db.Achievement).where(db.Achievement.user_id == make_message_user.id)
+        ).first()
+    if make_message_achievement:
+        make_message_achievement.messages_made += 1
+
     session.commit()
     session.refresh(new_message)
     return {

--- a/main.py
+++ b/main.py
@@ -148,6 +148,7 @@ async def make_message(room_id: int, data: MakeMessage, session: db.SessionDep):
     
     # メッセージ投稿者の実績（messages_made）を更新
     make_message_user = session.exec(db.select(db.User).where(db.User.name == data.user)).first()
+    make_message_achievement = None
     if make_message_user:
         make_message_achievement = session.exec(
             db.select(db.Achievement).where(db.Achievement.user_id == make_message_user.id)

--- a/my_db.py
+++ b/my_db.py
@@ -33,7 +33,7 @@ class Achievement(SQLModel, table=True):
     login_days: int = 1 #登録した時点でログイン1日目になるため
     likes_given: int = 0
     likes_received: int = 0
-    comments_made: int = 0
+    messages_made: int = 0
     rooms_created: int = 0
     streams_viewed: int = 0
 


### PR DESCRIPTION
## 概要
ユーザーがメッセージの作成時に、メッセージ投稿者のdb.Achievement.messages_madeの値を1追加するように変更しました。

## 変更点
- Achievementテーブルのcomments_madeカラムをmessageで統一するためにmessages_madeカラムに変更
- メッセージ投稿者のユーザー名(data.user)からdb.User.nameと一致するレコードをmake_message_userとし、make_message_user.idとdb.Achievement.user_idが一致するレコードをmake_message_achievementとする
- make_message_achievementがあればmessages_madeカラムの値を1追加