### PR TITLE
[feat]ルーム作成時にルーム作成者の実績の更新

### DIFF
--- a/main.py
+++ b/main.py
@@ -79,7 +79,7 @@ async def get_user(user_id: int, session: db.SessionDep):
             "likes_given": archievement.likes_given,
             "likes_received": archievement.likes_received,
             "messages_made": archievement.messages_made,
-            # "rooms_created": archievement.rooms_created,
+            "rooms_created": archievement.rooms_created,
             # "streams_viewed": archievement.streams_viewed,
         }
     else:
@@ -120,6 +120,15 @@ async def make_room(data: MakeRoom, session: db.SessionDep):
         youtube_id=data.youtubeId
     )
     session.add(new_room)
+    
+    # ルーム作成者の実績（rooms_created）を更新
+    make_room_achievement = None
+    make_room_achievement = session.exec(
+        db.select(db.Achievement).where(db.Achievement.user_id == data.user)
+    ).first()
+    if make_room_achievement:
+        make_room_achievement.rooms_created += 1
+    
     session.commit()
     session.refresh(new_room)
     return {


### PR DESCRIPTION
## 概要
ユーザーがルームを作成（配信）したときにルームを作成したユーザーのdb.Achievement.rooms_createdの値を1追加するように変更しました。

## 変更点
- ルーム作成回数の実績状況を取得できるように該当行のコメントアウトの解除
- data.userがユーザーIDであるためdata.userとdb.Achievement.user_idが一致しているレコードをmake_room_achievementとする
- make_room_achievementがあればrooms_createdカラムの値を1追加