### PR TITLE
[feat]ログイン時にログイン日数の実績の更新

### DIFF
--- a/main.py
+++ b/main.py
@@ -76,7 +76,7 @@ async def get_user(user_id: int, session: db.SessionDep):
     }
     if archievement:
         output["archievements"] = {
-            # "login_days": archievement.login_days,
+            "login_days": archievement.login_days,
             "likes_given": archievement.likes_given,
             "likes_received": archievement.likes_received,
             "messages_made": archievement.messages_made,

--- a/main.py
+++ b/main.py
@@ -79,7 +79,7 @@ async def get_user(user_id: int, session: db.SessionDep):
             "likes_given": archievement.likes_given,
             "likes_received": archievement.likes_received,
             "messages_made": archievement.messages_made,
-            # "rooms_created": archievement.rooms_created,
+            "rooms_created": archievement.rooms_created,
             # "streams_viewed": archievement.streams_viewed,
         }
     else:
@@ -120,6 +120,15 @@ async def make_room(data: MakeRoom, session: db.SessionDep):
         youtube_id=data.youtubeId
     )
     session.add(new_room)
+    
+    # ルーム作成者の実績（rooms_created）を更新
+    make_room_achievement = None
+    make_room_achievement = session.exec(
+        db.select(db.Achievement).where(db.Achievement.user_id == data.user)
+    ).first()
+    if make_room_achievement:
+        make_room_achievement.rooms_created += 1
+    
     session.commit()
     session.refresh(new_room)
     return {

--- a/main.py
+++ b/main.py
@@ -106,7 +106,10 @@ async def login_user(data: LoginUser, session: db.SessionDep):
         if login_achievement.last_login_date != today:
             login_achievement.login_days += 1
             login_achievement.last_login_date = today
-    
+            
+    session.add(login_achievement)
+    session.commit()
+    session.refresh(login_achievement)
     return {
         "id": user.id,
         "name": user.name
@@ -142,9 +145,11 @@ async def make_room(data: MakeRoom, session: db.SessionDep):
     ).first()
     if make_room_achievement:
         make_room_achievement.rooms_created += 1
-    
+        
+    session.add(make_room_achievement)
     session.commit()
     session.refresh(new_room)
+    session.refresh(make_room_achievement)
     return {
         "id": new_room.id,
         "title": new_room.title

--- a/my_db.py
+++ b/my_db.py
@@ -36,7 +36,8 @@ class Achievement(SQLModel, table=True):
     messages_made: int = 0
     rooms_created: int = 0
     streams_viewed: int = 0
-
+    last_login_date: str | None = None # その日初めてのログインかどうかを判定するため
+    
 sqlite_file_name = "database.db"
 sqlite_url = f"sqlite:///{sqlite_file_name}"
 

--- a/my_db.py
+++ b/my_db.py
@@ -30,7 +30,7 @@ class Like(SQLModel, table=True):
 class Achievement(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     user_id: int | None = Field(default=None, foreign_key="user.id")
-    login_days: int = 1 #登録した時点でログイン1日目になるため
+    login_days: int = 0
     likes_given: int = 0
     likes_received: int = 0
     messages_made: int = 0


### PR DESCRIPTION
## 概要
ユーザーがログイン時にその日初めてのログインであればユーザーのdb.Achievement.login_daysの値を1追加するように変更しました。

## 変更点
- Achievementテーブルにユーザーがその日初めてのログインかどうかを判別するためのlast_login_dateカラムの追加
- ログイン日数の実績状況を取得できるように該当行のコメントアウトの解除
- datetimeからdateのインポート
- ログインユーザーのID(user.id)とdb.Achievement.user_idが一致するレコードをlogin_achievementとする
- login_achievementがありかつその日初めてのログインであればllogin_daysカラムの値を1追加してlast_login_dateを更新